### PR TITLE
Update motion-firebase.rb to fix clang: error: no such file or directory: 'libc++.dylib'

### DIFF
--- a/lib/motion-firebase.rb
+++ b/lib/motion-firebase.rb
@@ -14,6 +14,6 @@ Motion::Project::App.setup do |app|
   end
 
   app.vendor_project(File.join(File.dirname(__FILE__), 'vendor/Firebase.framework'), :static, headers_dir: 'Headers', products: ['Firebase'])
-  app.libs += ['/usr/lib/libicucore.dylib', 'libc++.dylib']
+  app.libs += ['/usr/lib/libicucore.dylib', '/usr/lib/libc++.dylib']
   app.frameworks += ['CFNetwork', 'Security', 'SystemConfiguration']
 end


### PR DESCRIPTION
to fix build error: clang: error: no such file or directory: 'libc++.dylib'
