### PR TITLE
Changed unauth to call original Firebase unauth. N.b.: Spec is untested

### DIFF
--- a/lib/firebase/firebase.rb
+++ b/lib/firebase/firebase.rb
@@ -44,11 +44,13 @@ class Firebase
     return self
   end
 
+  alias_method :old_unauth, :unauth
+
   def unauth(&block)
-    if block
+    if block_given?
       unauthWithCompletionBlock(block)
     else
-      super()
+      old_unauth
     end
   end
 

--- a/spec/firebase_simple_auth_spec.rb
+++ b/spec/firebase_simple_auth_spec.rb
@@ -1,0 +1,27 @@
+describe 'SimpleAuth' do
+  before do
+    @firebase_ref = Firebase.alloc.initWithUrl(MOTION_FIREBASE_SPEC).childByAppendingPath('specs')
+    @auth         = FirebaseSimpleLogin.new(@fire_ref)
+  end
+
+  it "is wired up right" do
+    @firebase_ref.should.is_a?(Firebase)
+    @auth.should.is_a?(FirebaseSimpleLogin)
+  end
+
+  it "calls the original unauth method on logout" do
+    class Firebase
+      attr_reader :old_unauth_called
+
+      def initialize
+        @old_unauth_called = false
+      end
+
+      def old_unauth
+        @old_unauth_called = true
+      end
+
+      @auth.logout.should.change{@old_unauth_called}
+    end
+  end
+end


### PR DESCRIPTION
I still can't get the specs to run. I get:

```
Warning: already initialized constant FirechatNS
2014-06-14 16:49:08.105 motion-firebase[6302:70b] undefined method `describe' for main:TopLevel (NoMethodError)
```

The first line is a result of who knows what, but the second is a setup issue. A Rakefile and Gemfile that allow specs to run would be helpful.
