### PR TITLE
New facebook auth for firebase

### DIFF
--- a/lib/firebase/firebase_facebook_helper.rb
+++ b/lib/firebase/firebase_facebook_helper.rb
@@ -6,17 +6,17 @@ class Firebase
   end
 
   def open_facebook_session(options={}, &block)
-    ref = self
-    permissions = options[:permissions] || ['public_profile']
-    allow_ui = options.fetch(:allow_login_ui, true)
-    FBSession.openActiveSessionWithReadPermissions(permissions, allowLoginUI: allow_ui,
-      completionHandler: -> (session, state, error) do
-        if error
-          block.call(error, nil)
+    fb_login = FBSDKLoginManager.alloc.init
+    fb_login.logInWithReadPermissions(["email"], 
+      handler: -> (facebookResult, facebookError) do
+        if facebookError
+          block.call(facebookError, nil)
+        elsif facebookResult.isCancelled
+          block.call("Facebook login got cancelled.", nil)
         elsif state == FBSessionStateOpen
-          token = session.accessTokenData.accessToken
+          access_token = FBSDKAccessToken.currentAccessToken.tokenString
 
-          ref.authWithOAuthProvider('facebook', token:token, withCompletionBlock:block)
+          ref.authWithOAuthProvider('facebook', token: access_token, withCompletionBlock:block)
         end
       end)
     nil

--- a/lib/firebase/firebase_facebook_helper.rb
+++ b/lib/firebase/firebase_facebook_helper.rb
@@ -7,8 +7,9 @@ class Firebase
 
   def open_facebook_session(options={}, &block)
     ref = self
+    permissions = options[:permissions] || ['email']
     fb_login = FBSDKLoginManager.alloc.init
-    fb_login.logInWithReadPermissions(["email"], 
+    fb_login.logInWithReadPermissions(permissions, 
       handler: -> (facebookResult, facebookError) do
         if facebookError
           block.call(facebookError, nil)

--- a/lib/firebase/firebase_facebook_helper.rb
+++ b/lib/firebase/firebase_facebook_helper.rb
@@ -13,7 +13,7 @@ class Firebase
           block.call(facebookError, nil)
         elsif facebookResult.isCancelled
           block.call("Facebook login got cancelled.", nil)
-        elsif state == FBSessionStateOpen
+        else
           access_token = FBSDKAccessToken.currentAccessToken.tokenString
 
           ref.authWithOAuthProvider('facebook', token: access_token, withCompletionBlock:block)

--- a/lib/firebase/firebase_facebook_helper.rb
+++ b/lib/firebase/firebase_facebook_helper.rb
@@ -6,6 +6,7 @@ class Firebase
   end
 
   def open_facebook_session(options={}, &block)
+    ref = self
     fb_login = FBSDKLoginManager.alloc.init
     fb_login.logInWithReadPermissions(["email"], 
       handler: -> (facebookResult, facebookError) do


### PR DESCRIPTION
Facebook auth has changed for firebase: https://www.firebase.com/docs/ios/guide/login/facebook.html

Just a quick change to firebase_facebook_helper to get it working again.