### PR TITLE
Add option for callback on query

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ firebase.query(first: value)
 firebase.query(first: value, on: :added) do |snapshot|
 end
 
+# create a listener that only is executed once by providing a block and :once value
+firebase.query(first: value, once: :value) do |snapshot|
+end
+
 firebase.query(last: value)
 # => firebase.queryLimitedToLast(value)
 

--- a/lib/firebase/fquery.rb
+++ b/lib/firebase/fquery.rb
@@ -132,9 +132,15 @@ class FQuery
     end
 
     if block
-      event_type = options.fetch(:on, FEventTypeValue)
-      event_type = Firebase.convert_event_type(event_type)
-      return fb_query.observeEventType(event_type, withBlock: block)
+      if options[:once]
+        event_type = options.fetch(:once, FEventTypeValue)
+        event_type = Firebase.convert_event_type(event_type)
+        return fb_query.observeSingleEventOfType(event_type, withBlock: block)
+      else
+        event_type = options.fetch(:on, FEventTypeValue)
+        event_type = Firebase.convert_event_type(event_type)
+        return fb_query.observeEventType(event_type, withBlock: block)
+      end
     else
       fb_query
     end


### PR DESCRIPTION
Add a new parameter to `query` options to enable a callback that is only fired once instead of creating a listener to each query.